### PR TITLE
Mini-Service的AccountManagerTest测试在中文环境下不过

### DIFF
--- a/examples/mini-service/src/test/java/org/springside/examples/miniservice/service/AccountManagerTest.java
+++ b/examples/mini-service/src/test/java/org/springside/examples/miniservice/service/AccountManagerTest.java
@@ -19,6 +19,14 @@ public class AccountManagerTest extends SpringContextTestCase {
 	@Autowired
 	private AccountManager accountManager;
 
+	/*
+	* to avoid the non-English environment test failure on assertEquals.
+	*/
+    	@Before
+    	public void setUp() {
+        	LocaleContextHolder.setLocale(Locale.ENGLISH);
+    	}
+    
 	/**
 	 * 测试参数校验.
 	 */


### PR DESCRIPTION
assertEquals("loginName may not be empty",                 StringUtils.join(BeanValidators.extractPropertyAndMessage(e), ','));
这个语句执行的时候调用LocaleContextHolder生成了当前locale下的错误语句"loginName 不能为空"
造成两个String不等。
