### PR TITLE
Dao的名称冲突的时候可以使用别名

### DIFF
--- a/examples/showcase/src/main/java/org/springside/examples/showcase/repository/mybatis/MyBatisRepository.java
+++ b/examples/showcase/src/main/java/org/springside/examples/showcase/repository/mybatis/MyBatisRepository.java
@@ -1,9 +1,8 @@
 package org.springside.examples.showcase.repository.mybatis;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
+
+import org.springframework.stereotype.Component;
 
 /**
  * 标识MyBatis的DAO,方便{@link org.mybatis.spring.mapper.MapperScannerConfigurer}的扫描。
@@ -13,5 +12,8 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Documented
+@Component
 public @interface MyBatisRepository {
+    String value() default "";
 }


### PR DESCRIPTION
如果两个Dao的名称一样在启动的时候会加载错误，因为在context中的id名称一样起了冲突，原@MyBatisRepository注解并没有提供这个功能，我加了点代码让它可以支持别名。

``` Java

package org.springside.examples.showcase.repository.mybatis;

import java.lang.annotation.*;

import org.springframework.stereotype.Component;

/**
 * 标识MyBatis的DAO,方便{@link org.mybatis.spring.mapper.MapperScannerConfigurer}的扫描。
 * 
 * @author calvin
 *
 */
@Retention(RetentionPolicy.RUNTIME)
@Target(ElementType.TYPE)
@Documented
@Component
public @interface MyBatisRepository {
    String value() default "";
}


```
