### PR TITLE
在extension中添加jcl-over-slf4j依赖，解决test失败的问题

### DIFF
--- a/modules/extension/pom.xml
+++ b/modules/extension/pom.xml
@@ -69,6 +69,12 @@
 			<artifactId>logback-classic</artifactId>
 			<optional>true</optional>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jcl-over-slf4j</artifactId>
+		</dependency>
+
 
 		<!-- TEST -->
 		<dependency>


### PR DESCRIPTION
extension test fail，原因是junit调用了spring-test，而spring-test，使用的是commons-log接口，需要转换到slf4j。
