### PR TITLE
remove the unnecessary grep regex, and also the mutate filter.

### DIFF
--- a/support/logstash/error_collector/shipper.conf
+++ b/support/logstash/error_collector/shipper.conf
@@ -10,12 +10,8 @@ input {
 }
 
 filter {
-  if [type] != "showcase" or [message] !~ /(ERROR)|(^.+Exception: .+)|(^\s+at .+)|(^\?s+... \d+ more)|(^\s*Caused by:.+)/{  
-    drop {}                                             # 将非错误日志过滤掉
-  }
-
-  mutate {
-    replace => [ "message", "[%{host}]-%{message}" ]    # 将产生日志的host记录在日志记录中
+  if [type] != "showcase" or [message] !~ /(ERROR)|(^.+Exception: .+)/{
+    drop {}                                             # 将非错误日志过滤掉,因为之前已经将stacktrace拼接成一条记录,所以这里的过滤条件也比较简单,不需要复杂的正则表达式,只要带Error或者Exception就可以了
   }
 }
 


### PR DESCRIPTION
remove the complicated regex of the drop filter, because stack trace is already combined into one record.

also remove the mutate filter, using output format instead.
