### PR TITLE
change tcp input/output codec to 'line'

### DIFF
--- a/support/logstash/error_collector/collector.conf
+++ b/support/logstash/error_collector/collector.conf
@@ -4,7 +4,7 @@ input {    # 在TCP端口上侦听
     port => 6868
     mode => "server"
     type => "showcase"
-    codec => "plain"
+    codec => "line"   # 定义codec为line, 避免tcp input有时将多行日志并为一行的问题
   }
 }
 

--- a/support/logstash/error_collector/shipper.conf.example
+++ b/support/logstash/error_collector/shipper.conf.example
@@ -20,7 +20,7 @@ output {
   tcp {
     host => "127.0.0.1"
     port => 6868
-    codec => plain {  
+    codec => line {  
       format => "[%{host}]-%{message}"                   # 设置output的格式，仅输出HostName + 日志内容本身,不附加Timestamp
     }
   }


### PR DESCRIPTION
change tcp input/output codec to 'line', because tcp input sometimes does not split newlines, but join them into one line. 
see https://logstash.jira.com/browse/LOGSTASH-1370 for details.
