### PR TITLE
修复JedisShardedTemplateTest测试用例hashActions中的key命名错误

### DIFF
--- a/modules/extension/src/test/java/org/springside/modules/nosql/redis/JedisShardedTemplateTest.java
+++ b/modules/extension/src/test/java/org/springside/modules/nosql/redis/JedisShardedTemplateTest.java
@@ -67,7 +67,7 @@ public class JedisShardedTemplateTest {
 
 	@Test
 	public void hashActions() {
-		String key = "test.string.key";
+		String key = "test.hash.key";
 		String field1 = "aa";
 		String field2 = "bb";
 		String notExistField = field1 + "not.exist";


### PR DESCRIPTION
如题，那个地方应该是test.hash.key
