### PR TITLE
REST默认返回JSON格式

### DIFF
--- a/examples/showcase/src/main/webapp/WEB-INF/spring-mvc.xml
+++ b/examples/showcase/src/main/webapp/WEB-INF/spring-mvc.xml
@@ -28,6 +28,8 @@
 
 	<!-- REST中根据URL后缀自动判定Content-Type及相应的View -->
 	<bean id="contentNegotiationManager" class="org.springframework.web.accept.ContentNegotiationManagerFactoryBean">
+	    <property name="ignoreAcceptHeader" value="true" />
+            <property name="defaultContentType" value="application/json" />
 	    <property name="mediaTypes" >
 	        <value>
 	            json=application/json


### PR DESCRIPTION
由于request中accept header中默认加入xml参数，导致contentNegotiationManager默认返回XML（即使设置defaultContentType=json）
还有加入ignoreAcceptHeader=true
