### PR TITLE
在pom.xml中增加对com.google.guava的依赖包

### DIFF
--- a/modules/redis/pom.xml
+++ b/modules/redis/pom.xml
@@ -71,7 +71,13 @@
 			<artifactId>logback-classic</artifactId>
 			<optional>true</optional>
 		</dependency>
-	</dependencies>
+
+		<dependency>
+    			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
+
+</dependencies>
 
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
缺少对`com.google.guava`的依赖，导致 `import com.google.common.collect.Lists` 失败。
