### PR TITLE
修改hasPreviousPage、hasNextPage为hasPrevious、hasNext

### DIFF
--- a/examples/quickstart/src/main/webapp/WEB-INF/tags/pagination.tag
+++ b/examples/quickstart/src/main/webapp/WEB-INF/tags/pagination.tag
@@ -16,7 +16,7 @@ request.setAttribute("end", end);
 
 <div class="pagination">
 	<ul>
-		 <% if (page.hasPreviousPage()){%>
+		 <% if (page.hasPrevious()){%>
                	<li><a href="?page=1&sortType=${sortType}&${searchParams}">&lt;&lt;</a></li>
                 <li><a href="?page=${current-1}&sortType=${sortType}&${searchParams}">&lt;</a></li>
          <%}else{%>
@@ -35,7 +35,7 @@ request.setAttribute("end", end);
             </c:choose>
         </c:forEach>
 	  
-	  	 <% if (page.hasNextPage()){%>
+	  	 <% if (page.hasNext()){%>
                	<li><a href="?page=${current+1}&sortType=${sortType}&${searchParams}">&gt;</a></li>
                 <li><a href="?page=${page.totalPages}&sortType=${sortType}&${searchParams}">&gt;&gt;</a></li>
          <%}else{%>


### PR DESCRIPTION
hasPreviousPage、hasNextPage方法从spring-data-commons-1.9.0.RELEASE版本开始被移除，应替换为Slice类提供的hasPrevious、hasNext方法