### PR TITLE
/quickstart/src/main/webapp/WEB-INF/tags/pagination.tag错误修复

### DIFF
--- a/examples/quickstart/src/main/webapp/WEB-INF/tags/pagination.tag
+++ b/examples/quickstart/src/main/webapp/WEB-INF/tags/pagination.tag
@@ -16,7 +16,7 @@ request.setAttribute("end", end);
 
 <div class="pagination">
 	<ul>
-		 <% if (page.hasPreviousPage()){%>
+		 <% if (page.hasPrevious()){%>
                	<li><a href="?page=1&sortType=${sortType}&${searchParams}">&lt;&lt;</a></li>
                 <li><a href="?page=${current-1}&sortType=${sortType}&${searchParams}">&lt;</a></li>
          <%}else{%>
@@ -35,7 +35,7 @@ request.setAttribute("end", end);
             </c:choose>
         </c:forEach>
 	  
-	  	 <% if (page.hasNextPage()){%>
+	  	 <% if (page.hasNext()){%>
                	<li><a href="?page=${current+1}&sortType=${sortType}&${searchParams}">&gt;</a></li>
                 <li><a href="?page=${page.totalPages}&sortType=${sortType}&${searchParams}">&gt;&gt;</a></li>
          <%}else{%>


### PR DESCRIPTION
quickstart里修改了spring-data-jpa的版本为1.7.1.RELEASE，依赖了spring-data-commons-1.9.1.RELEASE.jar，新版本org.springframework.data.domain.Page接口不再有hasPreviousPage()和hasNextPage()方法
