### PR TITLE
fix bug: pom引用错误，导致IntelliJ Idea初次导入代码之后无法解析maven依赖

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -2,14 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>io.springside</groupId>
-		<artifactId>springside-parent</artifactId>
-		<version>5.0.0-SNAPSHOT</version>
-		<relativePath>../modules/parent/</relativePath>
-	</parent>	
 	<groupId>io.springside.examples</groupId>
 	<artifactId>springside-examples</artifactId>
+	<version>5.0.0-SNAPSHOT</version>
 	<name>Springside :: Examples</name>
 	<packaging>pom</packaging>
 

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>io.springside</groupId>
 		<artifactId>springside-modules</artifactId>
 		<version>5.0.0-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>springside-core</artifactId>
 	<packaging>jar</packaging>

--- a/modules/utils/pom.xml
+++ b/modules/utils/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>io.springside</groupId>
 		<artifactId>springside-modules</artifactId>
 		<version>5.0.0-SNAPSHOT</version>
-		<relativePath>../</relativePath>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>springside-utils</artifactId>
 	<packaging>jar</packaging>


### PR DESCRIPTION
更新代码到5.0.0之后，IntelliJ Idea对pom文件的解析没有报错（这个很奇怪），maven依赖一个都没有，百思不得其解，找了很久，才发现这个pom文件的这几处有点问题，修复之后，maven的依赖正常解析，并且能正常运行
