### PR TITLE
修改ObjectUtil

### DIFF
--- a/modules/utils/src/main/java/org/springside/modules/utils/base/ObjectUtil.java
+++ b/modules/utils/src/main/java/org/springside/modules/utils/base/ObjectUtil.java
@@ -43,25 +43,15 @@ public class ObjectUtil {
 					sb.append(Arrays.toString((short[]) value));
 				} else if (componentType == byte.class) {
 					sb.append(Arrays.toString((byte[]) value));
+				} else if (componentType == char.class) {
+					sb.append(Arrays.toString((char[]) value));
 				} else {
 					throw new IllegalArgumentException("unsupport array type");
 				}
 
 				return sb.toString();
-			} else {
-				StringBuilder sb = new StringBuilder();
-				sb.append('[');
-
-				Object[] array = (Object[]) value;
-				for (int i = 0; i < array.length; i++) {
-					if (i > 0) {
-						sb.append(", ");
-					}
-					sb.append(toPrettyString(array[i]));
-				}
-				sb.append(']');
-				return sb.toString();
 			}
+			return Arrays.toString((Object[]) value);
 		} else if (value instanceof Iterable) {
 			Iterable iterable = (Iterable) value;
 			StringBuilder sb = new StringBuilder();

--- a/modules/utils/src/test/java/org/springside/modules/utils/base/ObjectUtilTest.java
+++ b/modules/utils/src/test/java/org/springside/modules/utils/base/ObjectUtilTest.java
@@ -24,7 +24,8 @@ public class ObjectUtilTest {
 		assertThat(ObjectUtil.toPrettyString(new boolean[] { true, false })).isEqualTo("[true, false]");
 		assertThat(ObjectUtil.toPrettyString(new short[] { 1, 2 })).isEqualTo("[1, 2]");
 		assertThat(ObjectUtil.toPrettyString(new byte[] { 1, 2 })).isEqualTo("[1, 2]");
-		
+		assertThat(ObjectUtil.toPrettyString(new char[] { '1', '2' })).isEqualTo("[1, 2]");
+
 		assertThat(ObjectUtil.toPrettyString(new Integer[] { 1, 2 })).isEqualTo("[1, 2]");
 		assertThat(ObjectUtil.toPrettyString(ListUtil.newArrayList("1", "2"))).isEqualTo("{1,2}");
 	}


### PR DESCRIPTION
1. ObjectUtil.toPrettyString添加对char数组的处理
2. ObjectUtil.toPrettyString对Object数组的处理修改为直接调用Arrays.toString(Object[] a)