### PR TITLE
fix(sec): upgrade ch.qos.logback:logback-classic to 1.2.0

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -14,7 +14,7 @@
 		<guava.version>20.0</guava.version>
 		<commons-lang3.version>3.5</commons-lang3.version>
 		<slf4j.version>1.7.22</slf4j.version>
-		<logback.version>1.1.8</logback.version>
+		<logback.version>1.2.0</logback.version>
 		<junit.version>4.12</junit.version>
 		<assertj.version>2.6.0</assertj.version>
 		<mockito.version>1.10.19</mockito.version>

--- a/modules/metrics/pom.xml
+++ b/modules/metrics/pom.xml
@@ -9,7 +9,7 @@
 	<name>Springside :: Module :: Metrics</name>
 	<properties>
 		<slf4j.version>1.7.22</slf4j.version>
-		<logback.version>1.1.8</logback.version>
+		<logback.version>1.2.0</logback.version>
 		<junit.version>4.12</junit.version>
 		<assertj.version>2.6.0</assertj.version>
 		<mockito.version>1.10.19</mockito.version>

--- a/modules/utils/pom.xml
+++ b/modules/utils/pom.xml
@@ -12,7 +12,7 @@
 		<guava.version>20.0</guava.version>
 		<commons-lang3.version>3.7</commons-lang3.version>
 		<slf4j.version>1.7.25</slf4j.version>
-		<logback.version>1.1.8</logback.version>
+		<logback.version>1.2.0</logback.version>
 		<dozer.version>5.5.1</dozer.version>
 		<jackson.version>2.8.6</jackson.version>
 		<junit.version>4.12</junit.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in ch.qos.logback:logback-classic 1.1.8
- [CVE-2017-5929](https://www.oscs1024.com/hd/CVE-2017-5929)


### What did I do？
Upgrade ch.qos.logback:logback-classic from 1.1.8 to 1.2.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS